### PR TITLE
Fix an "Undefined index" in plugin settings page.

### DIFF
--- a/all-in-one-favicon.php
+++ b/all-in-one-favicon.php
@@ -160,10 +160,18 @@ class AllInOneFavicon {
 
     // Create and return array of default settings
     return array(
-      'aioFaviconVersion' => AIOFAVICON_VERSION,
-      'debugMode' => false,
+      'aioFaviconVersion'     => AIOFAVICON_VERSION,
+      'debugMode'             => false,
       'removeReflectiveShine' => false,
-      'removeLinkFromMetaBox' => true
+      'removeLinkFromMetaBox' => true,
+      'frontendICO'           => '',
+      'frontendGIF'           => '',
+      'frontendPNG'           => '',
+      'frontendApple'         => '',
+      'backendICO'            => '',
+      'backendGIF'            => '',
+      'backendPNG'            => '',
+      'backendApple'          => ''
     );
   }
 


### PR DESCRIPTION
I added missing keys with empty values to default settings.
In my WordPress 4.4 after activating the plugin I've got many PHP notices.

<img width="844" alt="screen shot 2016-01-12 at 15 54 40" src="https://cloud.githubusercontent.com/assets/335095/12264184/f5f20900-b945-11e5-9174-003093696b60.png">